### PR TITLE
Correct config file path on Unix-like system.

### DIFF
--- a/TerraformTool/ConfigData.cs
+++ b/TerraformTool/ConfigData.cs
@@ -10,7 +10,7 @@ namespace TerraformTool
         public bool Free = false;
         public static string GetConfigPath()
         {            
-            string text = Path.Combine(DataLocation.modsPath, "TerraformTool\\TerraformTool.xml");
+            string text = Path.Combine(DataLocation.modsPath, "TerraformTool", "TerraformTool.xml");
             if (!Directory.Exists(Path.GetDirectoryName(text)))
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(text));


### PR DESCRIPTION
Hello,

thanks for your mod! On my Linux system, it creates a file called TerraformTool\TerraformTool.xml
Note that all of this is the file name, as the backslash is not a path separator on Unix. I therefore humbly propose to use Path.Combine instead of the literatel backslash.

Cheers,
Mike
